### PR TITLE
Fix voxel-sky to work with voxel-engine >=0.7.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,11 @@ module.exports.Sky = Sky;
 
 Sky.prototype.tick = function() {
   this.fn.call(this, this.time);
-  this.outer.position.copy(this.game.cameraPosition());
-  this.inner.position.copy(this.game.cameraPosition());
-  this.ambient.position.copy(this.game.cameraPosition());
+  var pos = this.game.cameraPosition();
+  var vec = new this.game.THREE.Vector3(pos[0], pos[1], pos[2]);
+  this.outer.position.copy(vec);
+  this.inner.position.copy(vec);
+  this.ambient.position.copy(vec);
   this.time += this._speed;
   if (this.time > 2400) this.time = 0;
   return this;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "voxel-trajectory": "~0.1.0"
   },
   "devDependencies": {
-    "voxel-engine": "0.6.0",
+    "voxel-engine": "0.7.0",
     "voxel-perlin-terrain": "0.0.5",
     "voxel-forest": "0.0.0",
     "browservefy": "0.0.4",
@@ -41,8 +41,8 @@
     "voxel-player": "~0.1.0"
   },
   "peerDependencies": {
-    "voxel-engine": "0.6.0",
-    "voxel-player": "0.1.0"
+    "voxel-engine": ">=0.7.0",
+    "voxel-player": ">=0.1.0"
   },
   "keywords": [
     "voxel",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voxel-sky",
   "description": "A sky for voxel.js",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/shama/voxel-sky",
   "author": {
     "name": "Kyle Robinson Young",


### PR DESCRIPTION
Just a quick fix, this could be done better but not without reworking voxel-sky a bit.
