### PR TITLE
Ability to spin the sky in any axis and defaulting to z

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,9 +146,10 @@ Sky.prototype.createCanvas = function() {
   return material;
 };
 
-Sky.prototype.spin = function(r) {
-  this.inner.rotation.x = this.outer.rotation.x = r;
-  this.ambient.rotation.x = r + Math.PI;
+Sky.prototype.spin = function(r, axis) {
+  axis = axis || 'z';
+  this.inner.rotation[axis] = this.outer.rotation[axis] = r;
+  this.ambient.rotation[axis] = r + Math.PI;
   var t = traj(this.size/2, this.ambient.rotation);
   this.sunlight.position.set(t[0], t[1], t[2]);
   this.sunlight.lookAt(0, 0, 0);


### PR DESCRIPTION
Currently `spin`'s only param is `r` (angle), but it always rotates the x axis. I've added `axis` as a param. 

I've also changed the default axis to z, because usually east/west is represented by x and north/south by y (in 2D, z in 3D), so we should be rotating the z axis to make the sun, moon and stars go from the east to the west.
